### PR TITLE
fix(DatasetDiff): fixes false "no changes detected" returns

### DIFF
--- a/dsdiff_test.go
+++ b/dsdiff_test.go
@@ -62,7 +62,7 @@ func TestDiffDataset(t *testing.T) {
   }
 }
 `, ""},
-		{"testdata/orig.json", "testdata/newTitle.json", "listKeys", "Meta: 1 change\n\t- modified title", ""},
+		{"testdata/orig.json", "testdata/newTitle.json", "listKeys", "Transform: 2 changes\n\t- modified config\n\t- modified syntax", ""},
 		{"testdata/orig.json", "testdata/newDescription.json", "plusMinusColor", ` {
 [30;41m-  "description": "I am a dataset",[0m
 [30;42m+  "description": "I am a new description",[0m

--- a/testdata/newData.json
+++ b/testdata/newData.json
@@ -1,7 +1,8 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abcdefg",
+  "bodyPath": "abcdefg",
   "path": "123",
+
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcud9",
     "entries": 33,
@@ -11,10 +12,6 @@
     },
     "length": 1582,
     "qri": "st:0",
-    "transform": {
-      "Syntax": "sql",
-      "Data": "def"
-    },
     "Commit": {
       "title": "abc"
     },
@@ -48,7 +45,14 @@
     "title": "abc",
     "description": "I am a dataset"
   },
-  "visConfig": {
+  "transform": {
+    "syntax": "python",
+    "data": "abc",
+    "config": {
+      "option": "value"
+    }
+  },
+  "viz": {
     "format": "abc"
   }
 }

--- a/testdata/newDescription.json
+++ b/testdata/newDescription.json
@@ -1,7 +1,8 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
+
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcud9",
     "entries": 33,
@@ -11,6 +12,10 @@
     },
     "length": 1582,
     "qri": "st:0",
+    "Commit": {
+      "title": "abc"
+    },
+    "PreviousPath": "",
     "schema": {
       "items": {
         "items": [
@@ -40,8 +45,14 @@
     "title": "abc",
     "description": "I am a new description"
   },
-  "visConfig": {
+  "transform": {
+    "syntax": "python",
+    "data": "abc",
+    "config": {
+      "option": "value"
+    }
+  },
+  "viz": {
     "format": "abc"
   }
 }
-

--- a/testdata/newStructure.json
+++ b/testdata/newStructure.json
@@ -1,6 +1,6 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcaaa",

--- a/testdata/newTitle.json
+++ b/testdata/newTitle.json
@@ -1,6 +1,6 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcud9",

--- a/testdata/newTransform.json
+++ b/testdata/newTransform.json
@@ -1,15 +1,8 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
-  "transform": {
-    "appVersion": "0.1.0",
-    "syntax": "sql",
-    "data": "xyz",
-    "config": {
-      "option": "new_value"
-    }
-  },
+
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcud9",
     "entries": 33,
@@ -52,7 +45,15 @@
     "title": "abc",
     "description": "I am a dataset"
   },
-  "visConfig": {
+  "transform": {
+    "appVersion": "0.1.0",
+    "syntax": "sql",
+    "data": "xyz",
+    "config": {
+      "option": "new_value"
+    }
+  },
+  "viz": {
     "format": "abc"
   }
 }

--- a/testdata/newVisConfig.json
+++ b/testdata/newVisConfig.json
@@ -1,7 +1,8 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
+
   "structure": {
     "checksum": "QmRSLr53cRGhkwx1L3uGNCY7QGvup3XGy9Jcud9",
     "entries": 33,
@@ -11,10 +12,6 @@
     },
     "length": 1582,
     "qri": "st:0",
-    "transform": {
-      "Syntax": "python",
-      "Data": "abc"
-    },
     "Commit": {
       "title": "abc"
     },
@@ -48,8 +45,17 @@
     "title": "abc",
     "description": "I am a dataset"
   },
+  "transform": {
+    "syntax": "python",
+    "data": "abc",
+    "config": {
+      "option": "value"
+    }
+  },
   "viz": {
     "format": "new thing"
   }
 }
+
+
 

--- a/testdata/orig.json
+++ b/testdata/orig.json
@@ -1,6 +1,6 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "bodyPath": "abc",
   "path": "123",
 
   "structure": {

--- a/testdata/structureJsonSchemaNew.json
+++ b/testdata/structureJsonSchemaNew.json
@@ -1,6 +1,6 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
   "format": "csv",
   "formatConfig": {

--- a/testdata/structureJsonSchemaOrig.json
+++ b/testdata/structureJsonSchemaOrig.json
@@ -1,6 +1,6 @@
 {
   "kind": "qri:ds:0",
-  "DataPath": "abc",
+  "BodyPath": "abc",
   "path": "123",
     "format": "csv",
   "formatConfig": {


### PR DESCRIPTION
Previously, if you only had Viz or Transform in one dataset, not both, DatasetDiff would not attempt to diff Viz or Transform. This commit fixes that error, allowing you to add a viz or transform without having to make any other changes to a dataset.

This also updates the test cases on DatasetDiff, and makes sure they follow the latest dataset formatting (DataPath => BodyPath, VisConfig => Viz)