### PR TITLE
chore(deps): update module dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="v0.1.1"></a>
+# [v0.1.1](https://github.com/qri-io/dsdiff/compare/v0.1.0...v0.1.1) (2019-06-03)
+
+We had a cross-dependency issue with github.com/qri-io/jsonschema. This release should fix that.
+
+
 # 0.1.0 (2019-05-30)
 
 `dsdiff` is a utility for diffing datasets, currently a basic placeholder

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,8 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/qri-io/dataset v0.0.0-20190516191825-5a7de4a0f2d4
-	github.com/qri-io/jsonschema v0.1.0 // indirect
+	github.com/qri-io/jsonschema v0.1.1 // indirect
 	github.com/qri-io/qfs v0.1.0 // indirect
-	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,11 @@ github.com/qri-io/dataset v0.0.0-20190516191825-5a7de4a0f2d4 h1:UAGqUgNmOM4z4grI
 github.com/qri-io/dataset v0.0.0-20190516191825-5a7de4a0f2d4/go.mod h1:JF7Gsqd+3LU7lmOriBRtNVJ0HkciNX6aVjoMAM3bOdA=
 github.com/qri-io/jsonpointer v0.0.0-20190212172158-7f104febd1fd h1:A/otcrPitGkmouHBoyuvt7xFMVeGbNq2HLQGMgshdJE=
 github.com/qri-io/jsonpointer v0.0.0-20190212172158-7f104febd1fd/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH9v37ZaMV64=
-github.com/qri-io/jsonschema v0.1.0 h1:ASQbkkRJzJfTo+Lg84jPfFlwYtneNl3ZYx3vikIc8ac=
-github.com/qri-io/jsonschema v0.1.0/go.mod h1:rlnuSZCX0LfkXwEhqARuBp800hH8tKV/EtgeD3yVT8s=
+github.com/qri-io/jsonpointer v0.1.0 h1:OcTtTmorodUCRc2CZhj/ZwOET8zVj6uo0ArEmzoThZI=
+github.com/qri-io/jsonpointer v0.1.0/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH9v37ZaMV64=
+github.com/qri-io/jsonschema v0.1.0/go.mod h1:QpzJ6gBQ0GYgGmh7mDQ1YsvvhSgE4rYj0k8t5MBOmUY=
+github.com/qri-io/jsonschema v0.1.1 h1:t//Doa/gvMqJ0bDhG7PGIKfaWGGxRVaffp+bcvBGGEk=
+github.com/qri-io/jsonschema v0.1.1/go.mod h1:QpzJ6gBQ0GYgGmh7mDQ1YsvvhSgE4rYj0k8t5MBOmUY=
 github.com/qri-io/qfs v0.1.0 h1:XgDhon13qLlwJHI2m0FAc2EhZEcrqMPwizvgfQXHzB8=
 github.com/qri-io/qfs v0.1.0/go.mod h1:vZ5gVAYKaW8bDLh8U8DEr3s/1JyNzQJg1Rg9HYS+VZo=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
we had a cross-dependency issue with github.com/qri-io/jsonschema. This release should fix that